### PR TITLE
Passing functions as parameters

### DIFF
--- a/lib/cnpj.js
+++ b/lib/cnpj.js
@@ -31,7 +31,7 @@
   var CNPJ = {};
 
   CNPJ.format = function(number) {
-    return this.strip(number).replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, "$1.$2.$3/$4-$5");
+    return CNPJ.strip(number).replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, "$1.$2.$3/$4-$5");
   };
 
   CNPJ.strip = function(number) {
@@ -39,7 +39,7 @@
   };
 
   CNPJ.isValid = function(number) {
-    var stripped = this.strip(number);
+    var stripped = CNPJ.strip(number);
 
     // CNPJ must be defined
     if (!stripped) { return false; }
@@ -67,7 +67,7 @@
     numbers += verifierDigit(numbers);
     numbers += verifierDigit(numbers);
 
-    return (formatted ? this.format(numbers) : numbers);
+    return (formatted ? CNPJ.format(numbers) : numbers);
   };
 
   if (commonjs) {

--- a/lib/cpf.js
+++ b/lib/cpf.js
@@ -36,7 +36,7 @@
   var CPF = {};
 
   CPF.format = function(number) {
-    return this.strip(number).replace(/^(\d{3})(\d{3})(\d{3})(\d{2})$/, "$1.$2.$3-$4");
+    return CPF.strip(number).replace(/^(\d{3})(\d{3})(\d{3})(\d{2})$/, "$1.$2.$3-$4");
   };
 
   CPF.strip = function(number) {
@@ -44,7 +44,7 @@
   };
 
   CPF.isValid = function(number) {
-    var stripped = this.strip(number);
+    var stripped = CPF.strip(number);
 
     // CPF must be defined
     if (!stripped) { return false; }
@@ -72,7 +72,7 @@
     numbers += verifierDigit(numbers);
     numbers += verifierDigit(numbers);
 
-    return (formatted ? this.format(numbers) : numbers);
+    return (formatted ? CPF.format(numbers) : numbers);
   };
 
   if (commonjs) {

--- a/spec/cnpj.spec.js
+++ b/spec/cnpj.spec.js
@@ -55,4 +55,45 @@ describe("CNPJ", function() {
     expect(number).to.match(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/);
     expect(cnpj.isValid(number)).to.be.ok;
   });
+
+  it("should be possible to pass CNPJ.strip as parameter to other function", function (done) {
+    var executeStrip = function (strip) {
+      var number = strip("54550[752#0001..$55");
+      expect(number).to.eql("54550752000155");
+      done();
+    };
+
+    executeStrip(cnpj.strip);
+  });
+
+  it("should be possible to pass CNPJ.format as parameter to other function", function (done) {
+    var executeFormat = function (format) {
+      var number = format("54550752000155");
+      expect(number).to.eql("54.550.752/0001-55");
+      done();
+    };
+
+    executeFormat(cnpj.format);
+  });
+
+  it("should be possible to pass CPF.isValid as parameter to other function", function (done) {
+    var executeIsValid = function (isValid) {
+      expect(isValid("54.550.752/0001-55")).to.be.ok;
+      done();
+    };
+
+    executeIsValid(cnpj.isValid);
+  });
+
+  it("should be possible to pass CPF.generate as parameter to other function", function (done) {
+    var executeGenerate = function (generate) {
+      var number = generate(true);
+
+      expect(number).to.match(/^(\d{2}).(\d{3}).(\d{3})\/(\d{4})-(\d{2})$/);
+      expect(cnpj.isValid(number)).to.be.ok;
+      done();
+    };
+
+    executeGenerate(cnpj.generate);
+  });
 });

--- a/spec/cpf.spec.js
+++ b/spec/cpf.spec.js
@@ -56,4 +56,45 @@ describe("CPF", function() {
     expect(number).to.match(/^\d{3}\d{3}\d{3}\d{2}$/);
     expect(cpf.isValid(number)).to.be.ok;
   });
+
+  it("should be possible to pass CPF.strip as parameter to other function", function (done) {
+    var executeStrip = function (strip) {
+      var number = strip("295.379.955-93");
+      expect(number).to.eql("29537995593");
+      done();
+    };
+
+    executeStrip(cpf.strip);
+  });
+
+  it("should be possible to pass CPF.format as parameter to other function", function (done) {
+    var executeFormat = function (format) {
+      var number = format("29537995593");
+      expect(number).to.eql("295.379.955-93");
+      done();
+    };
+
+    executeFormat(cpf.format);
+  });
+
+  it("should be possible to pass CPF.isValid as parameter to other function", function (done) {
+    var executeIsValid = function (isValid) {
+      expect(isValid("295.379.955-93")).to.be.ok;
+      done();
+    };
+
+    executeIsValid(cpf.isValid);
+  });
+
+  it("should be possible to pass CPF.generate as parameter to other function", function (done) {
+    var executeGenerate = function (generate) {
+      var number = generate(true);
+
+      expect(number).to.match(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/);
+      expect(cpf.isValid(number)).to.be.ok;
+      done();
+    };
+
+    executeGenerate(cpf.generate);
+  });
 });


### PR DESCRIPTION
This PR solves an issue that arises when trying to pass the functions as parameters to other functions. This problem occurs because of the `this` binding, that changes when the function is passed as a parameter and executed afterwards.

Just changed the reference to `this` to a reference to either `CPF` or to `CNJP`.

Some tests were added to confirm that this solution works as expected.